### PR TITLE
add safe guard for metadata

### DIFF
--- a/lib/event-subscribers.loader.ts
+++ b/lib/event-subscribers.loader.ts
@@ -54,7 +54,7 @@ export class EventSubscribersLoader
 
   private subscribeScoped(wrapper: InstanceWrapper) {
     // There is no instance created, so let's create one for method analysis.
-    const prototype = wrapper.metatype.prototype;
+    const prototype = wrapper.metatype?.prototype;
     if(!prototype)
       return;
     const instanceForAnalysis = Object.create(prototype);


### PR DESCRIPTION
# Description:
- `wrapper.metatype` can be undefined for `ApplicationConfig` module and it's not required when creating Nestjs instance with `createApplicationContext()` which is used for Airflow worker or Scheduler

# Tickets
- https://makersights.atlassian.net/browse/ME-12839