### PR TITLE
do not allow preinstall or postinstall scripts to run

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @makersights:registry=https://npm.pkg.github.com
+ignore-scripts=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makersights/event-emitter-scoped",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makersights/event-emitter-scoped",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "6.4.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makersights/event-emitter-scoped",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
# Description
This stops executing any preinstall and postinstall scripts during build and also on development env when running "npm i"

# Jira Ticket Link:
https://makersights.atlassian.net/browse/ME-14651
