### PR TITLE
chore: add min-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 @makersights:registry=https://npm.pkg.github.com
 ignore-scripts=true
+min-release-age=5


### PR DESCRIPTION
## Summary

Adds `min-release-age=5` to `.npmrc` so npm/pnpm waits 5 days before pulling in newly-published package versions, reducing exposure to compromised releases.

Tracking ticket: https://www.notion.so/makersights/Ensure-N-day-age-of-packages-for-update-34f4f9b240ca805c807dc5a1b03c3365?v=29c4f9b240ca806a813c000cc3ec6922&source=copy_link

## Test plan

- [ ] CI green